### PR TITLE
Recover from API price check errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A fun program to run on your node.  It will send you alerts so you can keep up t
 
 ---
 
-##### Version: 0.3b
+##### Version: 0.4b
 
 ---
 ### FEATURES <a name="features"></a>

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Max Login Exceeded: 15
 | rewards | How many rewards you have earned so far. How much your collateral has increased since the last time the program ran (incremental). |
 | USD | What are your rewards worth in $USD.  How much has it changed `+` for increases, `()` for decreases. |
 | Splits | Based on the [splits](#config) setup in the configuration, it will show you `split1`/`split2` |
-| DAG Price | What is the current price, based on an API call in real time. (coingecko). **In the event an API call is unsuccessful after three attempts, an asterisk (*) will appear after the price to indicate the price is reflected from the last known log entry with a valid price.** |
+| DAG Price | What is the current price, based on an API call in real time. (coingecko). **In the event an API call is unsuccessful after three attempts, a triple asterisk(*) will appear after the price to indicate the price is reflected from the last known log entry with a valid price.** |
 | DAG Price Change | What was the change since the last lookup `+` for increases, `()` for decreases. |
 | Collateral Nodes | Based on the number of nodes you added to the [configuration](#config) file prior to running the program.  It will compute the number of Nodes you could possibly have. |
 | Collateral DAGs | Based on the number of nodes you added to the [configuration](#config) file prior to running the program.  It will compute the number of DAGs you should accumulated. | 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Max Login Exceeded: 15
 | rewards | How many rewards you have earned so far. How much your collateral has increased since the last time the program ran (incremental). |
 | USD | What are your rewards worth in $USD.  How much has it changed `+` for increases, `()` for decreases. |
 | Splits | Based on the [splits](#config) setup in the configuration, it will show you `split1`/`split2` |
-| DAG Price | What is the current price, based on an API call in real time. (coingecko) |
+| DAG Price | What is the current price, based on an API call in real time. (coingecko). **In the event an API call is unsuccessful after three attempts, an asterisk (*) will appear after the price to indicate the price is reflected from the last known log entry with a valid price.** |
 | DAG Price Change | What was the change since the last lookup `+` for increases, `()` for decreases. |
 | Collateral Nodes | Based on the number of nodes you added to the [configuration](#config) file prior to running the program.  It will compute the number of Nodes you could possibly have. |
 | Collateral DAGs | Based on the number of nodes you added to the [configuration](#config) file prior to running the program.  It will compute the number of DAGs you should accumulated. | 

--- a/classes/check_dag_status.py
+++ b/classes/check_dag_status.py
@@ -237,6 +237,8 @@ class CheckDagStatus():
 
 
     def calculate_dag_to_usd(self):
+        error_flag = False
+
         for n in range(0,4):
             # allow four attempts to retrieve new price before using last known price
             resp = requests.get('https://api.coingecko.com/api/v3/simple/price?ids=constellation-labs&vs_currencies=usd')
@@ -248,7 +250,9 @@ class CheckDagStatus():
                 # This means something went wrong.
                 # raise ApiError('GET /tasks/ {}'.format(resp.status_code))
                 if n > 2:
-                    self.retrieve_last_known_dag_price()
+                    self.get_calc_stats_variables("api_error")
+                    self.usd_dag_price = self.last_dag_usd
+                    error_flag = True
                     break
                 sleep(2)
                         
@@ -277,7 +281,11 @@ class CheckDagStatus():
         self.usd_str = f"USD: {main_price} {self.delta_usd}"
         if self.config.splits_enabled:
             self.usd_str += f"\n{split1}/{split2}"
-        self.usd_str += f"\nDAG @ ${self.usd_dag_price}\n"
+        self.usd_str += f"\nDAG @ ${self.usd_dag_price}"
+
+        if error_flag:
+            self.usd_str += "*"
+        self.usd_str += "\n"
 
         self.usd_dag_delta = "{:,.7f}".format(abs(self.last_dag_usd-self.usd_dag_price))
         if self.last_dag_usd-self.usd_dag_price < 0:

--- a/classes/check_dag_status.py
+++ b/classes/check_dag_status.py
@@ -112,7 +112,7 @@ class CheckDagStatus():
                 result_stream = os.popen(command)
                 self.current_result = result_stream.read()
                 if "Rewards" in command:
-                    self.calculate_stat_variables()
+                    self.get_calc_stats_variables("alert")
                     self.current_result = self.cleaner(self.current_result,"spaces")
                     format_update = self.current_result.split(":")
                     try:
@@ -139,21 +139,23 @@ class CheckDagStatus():
                     self.results.append(self.current_result)
 
 
-    def calculate_stat_variables(self):
+    def get_calc_stats_variables(self,action):
         f = open(self.config.dag_log_file)
         last_line = f.readlines()
         f.close()
 
         last_line = last_line[len(last_line)-1]
         last_line = last_line.split("|")
-        self.last_dag_count = float(last_line[1])
-        self.last_price_usd = float(last_line[2])
+
         self.last_dag_usd = float(last_line[3])
+        if action == "alert":
+            self.last_dag_count = float(last_line[1])
+            self.last_price_usd = float(last_line[2])
 
-        self.current_dag_count = self.cleaner(self.current_result,"dag_count")
+            self.current_dag_count = self.cleaner(self.current_result,"dag_count")
 
-        self.delta_dags = int(self.current_dag_count) - int(self.last_dag_count)
-        self.delta_dags = str(self.delta_dags)
+            self.delta_dags = int(self.current_dag_count) - int(self.last_dag_count)
+            self.delta_dags = str(self.delta_dags)
 
 
     def cleaner(self, line, action):

--- a/classes/check_dag_status.py
+++ b/classes/check_dag_status.py
@@ -284,7 +284,7 @@ class CheckDagStatus():
         self.usd_str += f"\nDAG @ ${self.usd_dag_price}"
 
         if error_flag:
-            self.usd_str += "*"
+            self.usd_str += "***"
         self.usd_str += "\n"
 
         self.usd_dag_delta = "{:,.7f}".format(abs(self.last_dag_usd-self.usd_dag_price))

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -1,5 +1,5 @@
 # DAG Node Alerting Script
-# v0.1b
+# v0.4b
 # Author: hgtp://netmet
 # ========================
 #


### PR DESCRIPTION
Added resilience to the API call to Coingecko, to check 3 times.  Use last good price on failure and an indication on the alert message that there was an error.