### PR TITLE
Fix issue no8

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,14 @@ A Python automation and status program to run on your node.  It will send you al
 
 ---
 
-##### Version: v2.0
+##### Version: v2.0.2
 
 ---
 ### CHANGES <a name="changes"></a>
 
-- **REMOVED BETA CLASSIFICATION**.  The `automation` program has been vetted over time and it is felt that it is ready to continue its lifecycle as a regular release.
-- `adminauto` script has been added to simplify the install, upgrade, start, and stop procedures previously done manually and requiring more interaction form an advanced point of view.  Also offers alternative to execute alerts, reports, and health checks.
-- Separated out emails from MMS in order to fix some buggy results in the MMS egress messaging.
-- Code refactoring.
-- Enable/Disable Intervals to allow health checks only.
-- Various Bug fixes.
-- Updated the `End of Day` report output to include collateral section.
-
+- Minor updates to some verbiage in the `adminauto` installation, configuration script
+- Fixes `0:00` to `0:00` multiple alerting bug
+- Fixes dynamic CPU core acquisition bug.
 
 ---
 ### FEATURES <a name="features"></a>
@@ -106,7 +101,7 @@ A Python automation and status program to run on your node.  It will send you al
 
 | command | Parameters | Optional |
 | ------- | :-------: | :------- | 
-| `python3 automation.py` | `alert` `report` `auto` `health` `silent` | `-p`, `v`, `&` |
+| `python3 automation.py` | `alert` `report` `auto` `health` `silent` | `-p`, `-v`, `&` |
 
 > `&` will run the system in the background until `ctl-c` performed.
 

--- a/adminauto
+++ b/adminauto
@@ -46,8 +46,8 @@ beta_version_found=false
 branch_name="main" # dev vs. prod
 declare -A userdata
 
-AUTOMATION_SCRIPT_VERSION="2.0.1"
-AUTOMATION_PROGRAM_VERSION="2.0"
+AUTOMATION_SCRIPT_VERSION="2.0.2"
+AUTOMATION_PROGRAM_VERSION="2.0.2"
 
 function dag_statement()
 {
@@ -74,6 +74,8 @@ function disclaimer()
     printf "I am not employeed by Constellation.io; however,\n"
     printf "I ${bld}${red}love${clr}${b_blk}${wht} the community and want to give back.\n\n"
     printf "${wht}DESIGNED TO WORK ON UBUNTU ONLY (at the current moment).\n"
+    printf "${red}MAKE SURE YOUR TERMINAL IS WIDE ENOUGH OTHERWISE SOME TEXT.\n"
+    printf "${red}WILL WRAP OVER ITSELF AND WILL LOOK UNCOMPRESHENSIBLE.\n"
     printf "${wht}Install directory: ${bld}${yel}\$HOME/cn_automation${clr}${b_blk}${wht}\n\n"
 }
 
@@ -615,7 +617,7 @@ function perform_configuration()
     if [[ ${userdata[continue_only]} = true ]]; then
         done_searching=false
         while [ $done_searching = false ]; do
-            printf "${cyn}Single word search only. ${mag}EG) ${wht}Los_Angeles\n"
+            printf "${cyn}Single word search only. ${mag}EG) ${wht}America/Los_Angeles\n"
             read -e -p "${yel}Enter search term to filter or <enter> for full list: ${b_blk}${wht}" tz_search
             if [[ -z $tz_search ]]; then
                 search_action="-a"
@@ -639,6 +641,7 @@ function perform_configuration()
     
     print_banner 1
 
+    # interval timer on/off
     printf "\n${bld}${mag}You may ${red}ONLY${mag} want health checks.\n"
     printf "You can disable the automation program alerts here and it will\n"
     printf "disable this feature, allowing only for health checks.${clr}${b_blk}${wht}\n"
@@ -1285,7 +1288,7 @@ printf "${b_blk}${wht}\n"
 
 case "$1" in
     -i) action="install";;
-    -u) action="upgrade";;
+    -u) action="install";;
     -a) action="alert" 
         if [[ $2 = "-p" ]]; then
             action="alert_console"

--- a/adminauto
+++ b/adminauto
@@ -43,8 +43,7 @@ config_steps=11
 current_step=1
 g_install_issue=false # global installation issue
 beta_version_found=false
-#branch_name="main" # dev vs. prod
-branch_name="fix-issue-no8" # dev vs. prod
+branch_name="main" # dev vs. prod
 declare -A userdata
 
 AUTOMATION_SCRIPT_VERSION="2.0.2"

--- a/adminauto
+++ b/adminauto
@@ -6,7 +6,7 @@
 #  stopping, and restarting the 
 #  constellation node automation program
 #  
-#  last update:  2021-09
+#  last update:  2021-10
 #  author:  hgtp://netmet
 #
 #  DISCLAIMER:  I do not work for 
@@ -43,7 +43,8 @@ config_steps=11
 current_step=1
 g_install_issue=false # global installation issue
 beta_version_found=false
-branch_name="main" # dev vs. prod
+#branch_name="main" # dev vs. prod
+branch_name="fix-issue-no8" # dev vs. prod
 declare -A userdata
 
 AUTOMATION_SCRIPT_VERSION="2.0.2"

--- a/automation.py
+++ b/automation.py
@@ -2,7 +2,7 @@
 # 
 #  Constellation Node Automation Program
 #  
-#  last update:  2021-08
+#  last update:  2021-10
 #  author:  hgtp://netmet
 #
 #  DISCLAIMER:  I do not work for 
@@ -11,7 +11,6 @@
 #  this is just a script to help the 
 #  community.
 #
-#  Version 2.0
 # ===================================== 
 
 import argparse
@@ -19,7 +18,7 @@ from classes.core import Core
 from classes.config_obj import Config
 from classes.logs import Logger
 
-def retrieve_arguments(version="2.0"):
+def retrieve_arguments(version="2.0.2"):
     dag_parser = argparse.ArgumentParser(description="dag alerting script")
 
     dag_parser.add_argument('Action',
@@ -53,7 +52,6 @@ def retrieve_arguments(version="2.0"):
 # ===================
 # Start
 # ===================
-
 
 if __name__ == "__main__":
     dag_args = retrieve_arguments()

--- a/classes/config_obj.py
+++ b/classes/config_obj.py
@@ -76,6 +76,7 @@ class Config():
         self.start_time = self.start_time.time()
         self.end_time = self.end_time.time()
         self.report_time = self.report_time.time()
+        self.last_run_hour = int(datetime.now(self.tz).strftime("%H"))
 
         # Final Test of Log Dates
         if self.action == "log":
@@ -337,7 +338,7 @@ class Config():
 
 
     def grab_cpu_cores(self):
-        result_stream = os.popen("cat /proc/cpuinfo | grep 'cpu cores' | awk '{print $4}' | tail -1")
+        result_stream = os.popen("lscpu | grep '^CPU(s):' | awk '{print $2}' | tail -1")
         current_load = float(result_stream.read())
         current_load = current_load - (1 - self.load)
         return current_load

--- a/classes/config_obj.py
+++ b/classes/config_obj.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from pprint import pprint
 import os
 import yaml
 import re
@@ -17,6 +18,9 @@ class Config():
         self.setup_flags()
         self.config_default_check()
         self.setup_dates_times()
+
+        # debug
+        # pprint(vars(self))
 
 
     def reload_needed(self):

--- a/classes/core.py
+++ b/classes/core.py
@@ -1,4 +1,3 @@
-import builtins
 from datetime import datetime, timedelta
 from time import sleep
 from pprint import pprint
@@ -115,22 +114,23 @@ class Core():
 
                 while True:
                     now = self.config.build_time(0,"forward")
+                    now_basic_time = now.strftime("%H:%M")
 
                     self.node_health(now)
 
-                    next_run = self.config.last_run + timedelta(minutes=self.config.alert_interval)
-                    next_run = next_run.strftime("%H:%M")
-                    next_run = datetime.strptime(next_run,"%H:%M").time()
-                    last_run = self.config.last_run.strftime("%H:%M")
-                    last_run = datetime.strptime(last_run,"%H:%M").time()
+                    self.next_run = self.config.last_run + timedelta(minutes=self.config.alert_interval)
+                    self.next_run = self.next_run.strftime("%H:%M")
+                    self.next_run = datetime.strptime(self.next_run,"%H:%M").time()
+                    self.last_run = self.config.last_run.strftime("%H:%M")
+                    self.last_run = datetime.strptime(self.last_run,"%H:%M").time()
 
-                    if (now >= self.config.start_time and now <= self.config.report_time) and last_run < self.config.report_time: 
+                    if (now >= self.config.start_time and now <= self.config.report_time) and self.last_run < self.config.report_time: 
                         if now == self.config.report_time:
                             self.config.last_run = datetime.now(self.config.tz)
                             self.config.create_report = True
                             self.config.silence_writelog = True
                             self.node_checkup()
-                        elif now >= next_run:
+                        elif now_basic_time == self.next_run:
                             self.config.last_run = datetime.now(self.config.tz)
                             self.config.create_report = False
                             self.config.silence_writelog = False

--- a/classes/core.py
+++ b/classes/core.py
@@ -114,7 +114,6 @@ class Core():
 
                 while True:
                     now = self.config.build_time(0,"forward")
-                    now_basic_time = now.strftime("%H:%M")
 
                     self.node_health(now)
 
@@ -130,7 +129,7 @@ class Core():
                             self.config.create_report = True
                             self.config.silence_writelog = True
                             self.node_checkup()
-                        elif now_basic_time == self.next_run:
+                        elif now >= self.next_run:
                             self.config.last_run = datetime.now(self.config.tz)
                             self.config.create_report = False
                             self.config.silence_writelog = False
@@ -139,8 +138,10 @@ class Core():
                                 # rebuild configuration because user modified
                                 self.config = Config(self.config.dag_args)
                                 break
-                                
-                            self.node_checkup()
+
+                            if self.config.last_run_hour < 23:    
+                                self.node_checkup()
+                            self.config.last_run_hour = int(self.config.last_run.strftime("%H"))
                         sleep(2)
                     else:
                         break

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -66,7 +66,7 @@ In order to properly display the text messages, it is highly recommended to use 
     cd ~
     ```
     ```
-    wget https://github.com/netmet1/constellation-node-automation/releases/download/v2.0/adminauto -O /usr/local/bin/adminauto; chmod +x /usr/local/bin/adminauto
+    wget https://github.com/netmet1/constellation-node-automation/releases/download/v2.0.2/adminauto -O /usr/local/bin/adminauto; chmod +x /usr/local/bin/adminauto
     ```
 
 1. Issue the following command and follow the prompts

--- a/docs/MANUAL_INSTALL.md
+++ b/docs/MANUAL_INSTALL.md
@@ -122,6 +122,7 @@ nodeuser@constellation-node:~/#
 4. Grab the latest release of the program from the github (here) repository: `releases` section
 
 **MAKE SURE YOU DOWNLOAD THE CORRECT VERSION (LATEST).** (example shows v2.0)
+**THIS MAY NOT BE THE CURRENT VERSION: This document will only be updated when the procedure changes.**
 ```
 wget https://github.com/netmet1/constellation-node-automation/archive/refs/tags/v2.0.tar.gz
 ```


### PR DESCRIPTION
closes #7 and closes #8 

- Minor updates to some verbiage in the `adminauto` installation configuration script.

- Fixes `0:00` to `0:00` multiple alerting bug
   - When the time hour reached 23:00, the comparison between the current time and next update inverted.  This caused the expression to evaluate to true between `23:00` and `00:00` resulting in excessive multiple alerts.
- Fixes dynamic CPU core acquisition bug.
  - Some images of Debian were not properly parsing the CPU dynamically when the program was initialized causing a float error that would exit the program (gracefully) but incorrectly.

